### PR TITLE
fix(angular): missing newline prior to code-block

### DIFF
--- a/Angular/Angular guidelines and best practices.md
+++ b/Angular/Angular guidelines and best practices.md
@@ -993,6 +993,7 @@ class MyComponent {
 We did pretty much the same thing, but a bit shorter.
 
 _Example #3_ - order during initial assignment alongside property declaration
+
 ```ts
 @Component(...)
 class MyComponent {


### PR DESCRIPTION
Current situation:

![image](https://user-images.githubusercontent.com/22882813/77533678-9ceb3a00-6e97-11ea-8ca9-116ad31c888f.png)

Can be found under section **Consider different initial assignment options**, example 3