### PR TITLE
Fix the highlight syntax in the import part

### DIFF
--- a/JavaScript/React.md
+++ b/JavaScript/React.md
@@ -38,7 +38,8 @@ JS Imports should be grouped into three categories:
 3. Assets
 
 Example:
-```javascript
+
+```js
 import { css } from 'emotion';
 import React from 'react';
 


### PR DESCRIPTION
Not sure if this is because of space between the `Example:` part, or the ` ```javascript` part, but this wasn't (isn't) rendered properly in the handbook.

It could be the fault of the handbook app ¯\\_(ツ)_/¯

https://infinum.com/handbook/books/frontend/javascript/react#file-importing