### PR TITLE
Fix nextjs introduction link

### DIFF
--- a/React/Getting started with React.md
+++ b/React/Getting started with React.md
@@ -12,7 +12,7 @@ In the next sections we will cover some topics related to React ecosystem used i
 - [Official documentation](https://nextjs.org/docs/getting-started)
 - [Learn next](https://nextjs.org/learn/basics/create-nextjs-app)
 - [Examples](https://github.com/vercel/next.js/tree/canary/examples)
-- [Handbook Introduction](/handbook/books/frontend/react/next/introduction)
+- [Handbook Introduction](/books/frontend/react/next/introduction)
 
 ### Typescript
 


### PR DESCRIPTION
The link is broken, this should fix it.