### PR TITLE
Managing node versions

### DIFF
--- a/Node/Managing Node-NPM versions.md
+++ b/Node/Managing Node-NPM versions.md
@@ -2,34 +2,59 @@
 
 ### Node release schedule
 
-Node.js has defined and predictable release plan. Each node version goes through 3 phases: current, active(LTS) and maintenance. Be aware that odd-numbered versions will not go through active and maintenance phases.
+Node.js has defined and predictable release plan. Depending on the Node release version number, the Node release can go through 3 different phases: current, active(LTS) and maintenance. Be aware that odd-numbered versions will not go through active and maintenance phases, while even numbered will go through them all.
 
 #### Current phase
 
-Incorporates most non-major changes that end up on `nodejs/node` main branch. New major releases are branched out every six months. Even-numbered versions are scheduled for release in April, while odd ones are scheduled for October.
+Releases within this phase incorporate most non-major changes that end up on `nodejs/node` main branch. New major releases are branched out every six months. Even-numbered versions are scheduled for release in April, while odd ones are scheduled for October.
 
 #### Active Long Term Support phase
 
-Versions in this phase include new features, bug fixes and updates that have been audited and determined to be stable for the release. With each odd-numbered release, previous even-numbered release will transition to LTS phase. Versions in this phase will receive active support for 12 months after they entered LTS phase.
+Releases within this phase include new features, bug fixes and updates that have been audited and determined to be stable for the release. With each odd-numbered release, previous even-numbered release will transition to LTS phase. Versions in this phase will receive active support for 12 months after they entered LTS phase.
 
 **You should always aim to use latest LTS version available on your project**
 
 #### Maintenance phase
 
-Versions in this phase will receive critical bug fixes and security updates for 18 months after it enters this phase.
+Releases within this phase will receive critical bug fixes and security updates for 18 months in case of LTS(even-numbered) and 2 months in case of regular(odd-numbered) releases after entering this phase.
 
 ### Ensuring same version of Node is being used on all environments
 
-It is very important to keep the same versions of Node across the environments. When you update the version of Node in your project, you should take appropriate actions that the new version is also propagated/updated on build/production servers by notifying people responsible for those environments. By not running the same versions you could run into unexpected problems with failing builds, incorrect dependencies etc.
+It is very important to keep the same version of Node across the environments. When you update the version of Node in your project, you should take appropriate actions that the new version is also propagated/updated on build/production servers by notifying people responsible for those environments. By not running the same versions you could run into unexpected problems with failing builds, incorrect dependencies etc.
 
 ### Managing versions
 
-There are couple of ways for managing versions of Node. I will list couple of options and generally, all options are fine as long as you are proficient at installing, updating and switching Node versions using that method. These probably aren't all available version managers on the internet, but are probably most popular.
+There are couple of ways for managing versions of Node. This section lists couple of options and generally, all options are fine as long as you are proficient at installing, updating and switching Node versions using that method. These probably aren't all available version managers on the internet, but are probably most popular.
+
+#### n
+
+[n](https://github.com/tj/n) is both powerful and easy to use version manager for Node and should be preferred method for managing Node versions.
+You can create a `.n-node-version`, `.node-version` or `.nvmrc` file containing a Node version number. Running `n auto` will look for version specified in one of those files in that order and switch to it.
+
+```bash
+#Install n by running script
+npm install -g n
+
+#Install latest Node version
+n latest
+
+#Install specific version of Node by specifying version or use an alias
+n <version>
+n lts
+
+#Execute to check Node version currently in use and available versions
+n
+
+#Uninstall Node version(this does not affect cached versions)
+n uninstall <version>
+
+#Uninstall cached Node version
+n rm <version>
+```
 
 #### nvm - Node version manager
 
-[Node version manager](https://github.com/nvm-sh/nvm) is both powerful and easy to use and should be preferred method for managing Node versions.
-You can create a `.nvmrc` file containing a Node version number. Running `use`, `install`, `which` etc. commands will use the version specified in the file if none was provided in the command line. When using `nvm` and installing global packages, those packages will only be global for that specific version. eg. You currently use Node 16 and install `polyglot-cli`, if you switch to v18, the package won't be available there until you install it.
+[Node version manager](https://github.com/nvm-sh/nvm) is a version manager similar to `n` and a good alternative. You can create a `.nvmrc` file containing a Node version number. Running `use`, `install`, `which` etc. commands will use the version specified in the file if none was provided in the command line. When using `nvm` and installing global packages, those packages will only be global for that specific version. eg. You currently use Node 16 and install `polyglot-cli`, if you switch to v18, the package won't be available there until you install it.
 
 ```bash
 #Install NVM by running script
@@ -56,35 +81,38 @@ nvm use default
 nvm uninstall <version>
 ```
 
-#### n
+#### nvm - Node version manager
 
-[n](https://github.com/tj/n) is a version manager similar to `nvm` and a good alternative
-You can create a `.n-node-version`, `.node-version` or `.nvmrc` file containing a Node version number. Running `n auto` will look for version specified in one of those files in that order and switch to it.
+[Node version manager](https://github.com/nvm-sh/nvm) is a version manager similar to `n` and a good alternative. You can create a `.nvmrc` file containing a Node version number. Running `use`, `install`, `which` etc. commands will use the version specified in the file if none was provided in the command line. When using `nvm` and installing global packages, those packages will only be global for that specific version. eg. You currently use Node 16 and install `polyglot-cli`, if you switch to v18, the package won't be available there until you install it.
 
 ```bash
-#Install n by running script
-npm install -g n
+#Install NVM by running script
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
 
 #Install latest Node version
-n latest
+nvm install node
 
 #Install specific version of Node by specifying version or use an alias
-n <version>
-n lts
+nvm install <version>
+nvm install <alias>
 
-#Execute to check Node version currently in use and available versions
-n
+#Check Node version currently in use and available versions
+nvm ls
 
-#Uninstall Node version(this does not affect cached versions)
-n uninstall <version>
+#Set default version
+nvm alias default <version>
 
-#Uninstall cached Node version
-n rm <version>
+#Switching between Node versions
+nvm use <version>
+nvm use default
+
+#Uninstall Node version
+nvm uninstall <version>
 ```
 
 #### Using homebrew
 
-For this method you need to have [homebrew](https://brew.sh/) installed on your Mac(which you probably do). There might be additional steps required when switching versions using `brew` as switching is not supported, so you might need to uninstall and unlink the old version, and install and link new one.
+For this method you need to have [homebrew](https://brew.sh/) installed on your Mac(which you probably do). There might be additional steps required when switching versions using `brew` as switching is not supported, so you might need to uninstall and unlink the old version, and install and link new one. Using this method for managing Node versions is discouraged as it is likely that issues will occur at some point if multiple versions are needed.
 
 ```bash
 #Install Node
@@ -106,7 +134,7 @@ Considering previously mentioned options, there is no particular advantage why y
 
 #### avn - Automatic Version Switching
 
-[avn](https://github.com/wbyoung/avn) is a package for automatic version switching of Node using one of your Node version manager package. Currently supported are `nvm`, `n` and `nodebrew`. When you `cd` into a directory containing `.node-version` file, `avn` will automatically detect the change and use version manager of your choice to switch to the specified version.
+[avn](https://github.com/wbyoung/avn) is a package for automatic version switching of Node using one of your Node version manager package. Currently supported version managing packages are `n`, `nvm` and `nodebrew`. This package is not mandatory and will only work in conjunction with one of the version managing tools. When you `cd` into a directory containing `.node-version` file, `avn` will automatically detect the change and use version manager of your choice to switch to the specified version. Given the `.node-version` and `avn` support, it would be recommended to use `n` as version manager.
 
 ```bash
 #Install the packages

--- a/Node/Managing Node-NPM versions.md
+++ b/Node/Managing Node-NPM versions.md
@@ -1,27 +1,66 @@
-recommended setup
+## Node version management
 
-be careful how you install global packages, as they will be installed globally per package
+### Node release schedule
 
-how to install which managers, nvm n homebrew, direct binary install
+Node.js has defined and predictable release plan. Each node version goes through 3 phases: current, active(LTS) and maintenance. Be aware that odd-numbered versions will not go through active nad maintenance phases.
+
+#### Current phase
+
+Incorporates most non major changes that end up on `nodejs/node` main branch. New major releases are branched out every six months. Even-numbered versions are scheduled for release in April, while odd ones are scheduled for October.
+
+#### Active Long Term Support phase
+
+Versions in this phase include new features, bug fixes and updates that have been audited and determined to be stable for the release. With each odd-numbered release, previous even-numbered release will transition to LTS phase. Versions in this phase will receive active support for 12 months after they entered LTS phase.
+
+**You should always aim to use latest LTS version available on your project**
+
+#### Maintenance phase
+
+Versions in this phase will receive critical bug fixes and security updates for 18 months after it enters this phase.
+
+### Managing versions
+
+There are couple of ways for managing versions of Node. I will list couple of options and generally, all options are fine as long as you are proficient at installing, updating and switching Node versions using that method.
+
+(Discuss if any of the method should be default/preferred)
+
+#### nvm - Node version manager
+
+.nvmrc file
+
+#### n
+
+.n file
+
+#### avn - Automatic Version Switching
+
+#### Using homebrew
+
+For this method you need to have `homebrew` installed on your Mac(which you probably do). There might be additional steps required when switching versions using `brew` as switching is not supported, so you might need to uninstall and unlink the old version, and install and link new one.
+
+```bash
+#Install Node
+brew install node
+
+#Install specific version of node
+brew install node@14
+
+#Update Node
+brew upgrade node
+
+#Uninstall Node
+brew uninstall node
+```
+
+#### Using direct binary install
 
 advantages and disadvantages
 
--add voskas comment
+recommended setup
 
-phases
-node has 3 main phases - current incorporates most non major changes on main branch, every 6 months
--active lts, new features, bug fixes and updates that are stable for the release. every lts major version is actively maintained for 12 months after it enters lts - versions in maint mode, only critical bug fixes and security updates are included, those versions are maintained for 18 months since they enter the status
-
-you should aim to actively have the latest LTS version available
-
----
-
-i wouldn't add too many options here, i believe this should recommended by the team
 where should you enter which node version should be used
 package.json -> engines
 .node-version file for avn
-.nvm file for nvm
-.n file for n
 
 for each write down steps for installing, switching, removing, and using node versions
 writing down useful commands, like nvm ls

--- a/Node/Managing Node-NPM versions.md
+++ b/Node/Managing Node-NPM versions.md
@@ -20,84 +20,24 @@ Releases within this phase will receive critical bug fixes and security updates 
 
 ### Ensuring same version of Node is being used on all environments
 
-It is very important to keep the same version of Node across the environments. When you update the version of Node in your project, you should take appropriate actions that the new version is also propagated/updated on build/production servers by notifying people responsible for those environments. By not running the same versions you could run into unexpected problems with failing builds, incorrect dependencies etc.
+It is very important to keep the same version of Node across the environments. When you update the version of Node in your project, you should take appropriate actions that the new version is also propagated/updated on build/production servers by notifying people responsible for those environments. By not running the same versions you could run into unexpected problems with failing builds, incorrect dependencies etc. In case you are using server-side rendering, for example Next.js or Angular Universal you need to make sure that the same Node version is used on build server during the build step and on the production server when running the app.
 
 ### Managing versions
 
-There are couple of ways for managing versions of Node. This section lists couple of options and generally, all options are fine as long as you are proficient at installing, updating and switching Node versions using that method. These probably aren't all available version managers on the internet, but are probably most popular.
+There are couple of ways for managing versions of Node. This section lists couple of options and generally, all options are fine as long as you are proficient at installing, updating and switching Node versions using that method. These probably aren't all available version managers on the internet, but are probably most popular. Check the official documentation of each tool for installation and usage instructions as they differ between OSs and can change over time.
 
 #### n
 
 [n](https://github.com/tj/n) is both powerful and easy to use version manager for Node and should be preferred method for managing Node versions.
 You can create a `.n-node-version`, `.node-version` or `.nvmrc` file containing a Node version number. Running `n auto` will look for version specified in one of those files in that order and switch to it.
 
-```bash
-#Install n by running script
-npm install -g n
-
-#Install latest Node version
-n latest
-
-#Install specific version of Node by specifying version or use an alias
-n <version>
-n lts
-
-#Execute to check Node version currently in use and available versions
-n
-
-#Uninstall Node version(this does not affect cached versions)
-n uninstall <version>
-
-#Uninstall cached Node version
-n rm <version>
-```
-
 #### nvm - Node version manager
 
 [Node version manager](https://github.com/nvm-sh/nvm) is a version manager similar to `n` and a good alternative. You can create a `.nvmrc` file containing a Node version number. Running `use`, `install`, `which` etc. commands will use the version specified in the file if none was provided in the command line. When using `nvm` and installing global packages, those packages will only be global for that specific version. eg. You currently use Node 16 and install `polyglot-cli`, if you switch to v18, the package won't be available there until you install it.
 
-```bash
-#Install NVM by running script
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
-
-#Install latest Node version
-nvm install node
-
-#Install specific version of Node by specifying version or use an alias
-nvm install <version>
-nvm install <alias>
-
-#Check Node version currently in use and available versions
-nvm ls
-
-#Set default version
-nvm alias default <version>
-
-#Switching between Node versions
-nvm use <version>
-nvm use default
-
-#Uninstall Node version
-nvm uninstall <version>
-```
-
 #### Using homebrew
 
 For this method you need to have [homebrew](https://brew.sh/) installed on your Mac(which you probably do). There might be additional steps required when switching versions using `brew` as switching is not supported, so you might need to uninstall and unlink the old version, and install and link new one. Using this method for managing Node versions is discouraged as it is likely that issues will occur at some point if multiple versions are needed.
-
-```bash
-#Install Node
-brew install node
-
-#Install specific version of node
-brew install node@<version>
-
-#Update Node
-brew upgrade node
-
-#Uninstall Node
-brew uninstall node
-```
 
 #### Using direct binary install
 
@@ -107,20 +47,15 @@ Considering previously mentioned options, there is no particular advantage why y
 
 [avn](https://github.com/wbyoung/avn) is a package for automatic version switching of Node using one of your Node version manager package. Currently supported version managing packages are `n`, `nvm` and `nodebrew`. This package is not mandatory and will only work in conjunction with one of the version managing tools. When you `cd` into a directory containing `.node-version` file, `avn` will automatically detect the change and use version manager of your choice to switch to the specified version. Given the `.node-version` and `avn` support, it would be recommended to use `n` as version manager.
 
-```bash
-#Install the packages
-npm install -g avn avn-nvm avn-n
-avn setup
-```
-
 #### Specifying version in package.json
 
-You can specify the version of node that your stuff works on by providing Node versions in package.json. If you don't specify this, it means any version will do.
+You can specify the version of node that your stuff works on by providing Node versions in package.json. If you don't specify this, it means any version will do. It is also possible to specify version of `npm` as it is possible that even the minor version updates cause breaking changes.
 
 ```json
 {
   "engines": {
-    "node": ">= 18.12"
+    "node": ">= 18.12",
+    "npm": "8.19.3"
   }
 }
 ```

--- a/Node/Managing Node-NPM versions.md
+++ b/Node/Managing Node-NPM versions.md
@@ -1,0 +1,33 @@
+recommended setup
+
+be careful how you install global packages, as they will be installed globally per package
+
+how to install which managers, nvm n homebrew, direct binary install
+
+advantages and disadvantages
+
+-add voskas comment
+
+phases
+node has 3 main phases - current incorporates most non major changes on main branch, every 6 months
+-active lts, new features, bug fixes and updates that are stable for the release. every lts major version is actively maintained for 12 months after it enters lts - versions in maint mode, only critical bug fixes and security updates are included, those versions are maintained for 18 months since they enter the status
+
+you should aim to actively have the latest LTS version available
+
+---
+
+i wouldn't add too many options here, i believe this should recommended by the team
+where should you enter which node version should be used
+package.json -> engines
+.node-version file for avn
+.nvm file for nvm
+.n file for n
+
+for each write down steps for installing, switching, removing, and using node versions
+writing down useful commands, like nvm ls
+
+How to ensure that developer, build server and production server all use the same version of node
+^ not really sure what is the correct answer here, is this aimed at that server uses the same version by mentioning it somewhere in the code
+
+and why is that important
+to avoid version mismatch, example locally you are using node 14 to install packages, but on server you are using node 16, and the installation might fail

--- a/Node/Managing Node-NPM versions.md
+++ b/Node/Managing Node-NPM versions.md
@@ -81,35 +81,6 @@ nvm use default
 nvm uninstall <version>
 ```
 
-#### nvm - Node version manager
-
-[Node version manager](https://github.com/nvm-sh/nvm) is a version manager similar to `n` and a good alternative. You can create a `.nvmrc` file containing a Node version number. Running `use`, `install`, `which` etc. commands will use the version specified in the file if none was provided in the command line. When using `nvm` and installing global packages, those packages will only be global for that specific version. eg. You currently use Node 16 and install `polyglot-cli`, if you switch to v18, the package won't be available there until you install it.
-
-```bash
-#Install NVM by running script
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
-
-#Install latest Node version
-nvm install node
-
-#Install specific version of Node by specifying version or use an alias
-nvm install <version>
-nvm install <alias>
-
-#Check Node version currently in use and available versions
-nvm ls
-
-#Set default version
-nvm alias default <version>
-
-#Switching between Node versions
-nvm use <version>
-nvm use default
-
-#Uninstall Node version
-nvm uninstall <version>
-```
-
 #### Using homebrew
 
 For this method you need to have [homebrew](https://brew.sh/) installed on your Mac(which you probably do). There might be additional steps required when switching versions using `brew` as switching is not supported, so you might need to uninstall and unlink the old version, and install and link new one. Using this method for managing Node versions is discouraged as it is likely that issues will occur at some point if multiple versions are needed.

--- a/Node/Managing Node-NPM versions.md
+++ b/Node/Managing Node-NPM versions.md
@@ -2,11 +2,11 @@
 
 ### Node release schedule
 
-Node.js has defined and predictable release plan. Each node version goes through 3 phases: current, active(LTS) and maintenance. Be aware that odd-numbered versions will not go through active nad maintenance phases.
+Node.js has defined and predictable release plan. Each node version goes through 3 phases: current, active(LTS) and maintenance. Be aware that odd-numbered versions will not go through active and maintenance phases.
 
 #### Current phase
 
-Incorporates most non major changes that end up on `nodejs/node` main branch. New major releases are branched out every six months. Even-numbered versions are scheduled for release in April, while odd ones are scheduled for October.
+Incorporates most non-major changes that end up on `nodejs/node` main branch. New major releases are branched out every six months. Even-numbered versions are scheduled for release in April, while odd ones are scheduled for October.
 
 #### Active Long Term Support phase
 
@@ -18,32 +18,80 @@ Versions in this phase include new features, bug fixes and updates that have bee
 
 Versions in this phase will receive critical bug fixes and security updates for 18 months after it enters this phase.
 
+### Ensuring same version of Node is being used on all environments
+
+It is very important to keep the same versions of Node across the environments. When you update the version of Node in your project, you should take appropriate actions that the new version is also propagated/updated on build/production servers by notifying people responsible for those environments. By not running the same versions you could run into unexpected problems with failing builds, incorrect dependencies etc.
+
 ### Managing versions
 
-There are couple of ways for managing versions of Node. I will list couple of options and generally, all options are fine as long as you are proficient at installing, updating and switching Node versions using that method.
-
-(Discuss if any of the method should be default/preferred)
+There are couple of ways for managing versions of Node. I will list couple of options and generally, all options are fine as long as you are proficient at installing, updating and switching Node versions using that method. These probably aren't all available version managers on the internet, but are probably most popular.
 
 #### nvm - Node version manager
 
-.nvmrc file
+[Node version manager](https://github.com/nvm-sh/nvm) is both powerful and easy to use and should be preferred method for managing Node versions.
+You can create a `.nvmrc` file containing a Node version number. Running `use`, `install`, `which` etc. commands will use the version specified in the file if none was provided in the command line. When using `nvm` and installing global packages, those packages will only be global for that specific version. eg. You currently use Node 16 and install `polyglot-cli`, if you switch to v18, the package won't be available there until you install it.
+
+```bash
+#Install NVM by running script
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
+
+#Install latest Node version
+nvm install node
+
+#Install specific version of Node by specifying version or use an alias
+nvm install <version>
+nvm install <alias>
+
+#Check Node version currently in use and available versions
+nvm ls
+
+#Set default version
+nvm alias default <version>
+
+#Switching between Node versions
+nvm use <version>
+nvm use default
+
+#Uninstall Node version
+nvm uninstall <version>
+```
 
 #### n
 
-.n file
+[n](https://github.com/tj/n) is a version manager similar to `nvm` and a good alternative
+You can create a `.n-node-version`, `.node-version` or `.nvmrc` file containing a Node version number. Running `n auto` will look for version specified in one of those files in that order and switch to it.
 
-#### avn - Automatic Version Switching
+```bash
+#Install n by running script
+npm install -g n
+
+#Install latest Node version
+n latest
+
+#Install specific version of Node by specifying version or use an alias
+n <version>
+n lts
+
+#Execute to check Node version currently in use and available versions
+n
+
+#Uninstall Node version(this does not affect cached versions)
+n uninstall <version>
+
+#Uninstall cached Node version
+n rm <version>
+```
 
 #### Using homebrew
 
-For this method you need to have `homebrew` installed on your Mac(which you probably do). There might be additional steps required when switching versions using `brew` as switching is not supported, so you might need to uninstall and unlink the old version, and install and link new one.
+For this method you need to have [homebrew](https://brew.sh/) installed on your Mac(which you probably do). There might be additional steps required when switching versions using `brew` as switching is not supported, so you might need to uninstall and unlink the old version, and install and link new one.
 
 ```bash
 #Install Node
 brew install node
 
 #Install specific version of node
-brew install node@14
+brew install node@<version>
 
 #Update Node
 brew upgrade node
@@ -54,19 +102,26 @@ brew uninstall node
 
 #### Using direct binary install
 
-advantages and disadvantages
+Considering previously mentioned options, there is no particular advantage why you would use binary installation. You can still opt in to do so if you wish.
 
-recommended setup
+#### avn - Automatic Version Switching
 
-where should you enter which node version should be used
-package.json -> engines
-.node-version file for avn
+[avn](https://github.com/wbyoung/avn) is a package for automatic version switching of Node using one of your Node version manager package. Currently supported are `nvm`, `n` and `nodebrew`. When you `cd` into a directory containing `.node-version` file, `avn` will automatically detect the change and use version manager of your choice to switch to the specified version.
 
-for each write down steps for installing, switching, removing, and using node versions
-writing down useful commands, like nvm ls
+```bash
+#Install the packages
+npm install -g avn avn-nvm avn-n
+avn setup
+```
 
-How to ensure that developer, build server and production server all use the same version of node
-^ not really sure what is the correct answer here, is this aimed at that server uses the same version by mentioning it somewhere in the code
+#### Specifying version in package.json
 
-and why is that important
-to avoid version mismatch, example locally you are using node 14 to install packages, but on server you are using node 16, and the installation might fail
+You can specify the version of node that your stuff works on by providing Node versions in package.json. If you don't specify this, it means any version will do.
+
+```json
+{
+  "engines": {
+    "node": ">= 18.12"
+  }
+}
+```


### PR DESCRIPTION
This PR adds a chapter about managing Node versions. I currently have a dilemma if another section should be added stating what preferred/go-to version manager should be used team/project-wise. I wouldn't force anyone to use this or that, but having a default package seems like a good idea.