### PR TITLE
Change the URL to the official React docs

### DIFF
--- a/React/Getting started/Official documentation.md
+++ b/React/Getting started/Official documentation.md
@@ -1,4 +1,4 @@
-If you're searching for the tutorial to kick off learning React, you could first check [the official docs](https://reactjs.org/docs).
+If you're searching for the tutorial to kick off learning React, you could first check [the official docs](https://react.dev/).
 
 ## Learn concepts
 


### PR DESCRIPTION
The link for the official React docs lead to the legacy page. The URL was changed to match the new one.