### PR TITLE
Fix editorconfig indent_style for yaml extensions

### DIFF
--- a/Code Quality/Tools.md
+++ b/Code Quality/Tools.md
@@ -171,6 +171,9 @@ indent_style = tab
 indent_size = 2 # GitHub uses this value for indentation size when showing code on the Web
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_style = space
 ```
 
 ### ESLint and TSLint


### PR DESCRIPTION
Space indentation is language specific for YAML