### PR TITLE
pnpm

### DIFF
--- a/Angular/Angular guidelines and best practices/Core libraries, configuration and tools.md
+++ b/Angular/Angular guidelines and best practices/Core libraries, configuration and tools.md
@@ -2,7 +2,7 @@
 
 The best way to create a new project is by using Angular CLI. It will hide a lot of configuration behind the scenes (you will not have a Webpack config exposed for editing), do some optimizations when compiling your code, and offer some handy scaffolding tools.
 
-Install Angular CLI globally with `npm install -g @angular/cli` and check out what you can do with `ng help`.
+Install Angular CLI globally with `pnpm install -g @angular/cli` and check out what you can do with `ng help`.
 
 ## Creating a new project
 
@@ -105,8 +105,8 @@ This handbook will not cover all `ng` commands; please check out [Angular CLI Do
 If you are using a JS library that is not written in TypeScript, you can usually install typings separately. Install typings as a dev-dependency, for example:
 
 ```bash
-npm install --save d3
-npm install --save-dev @types/d3
+pnpm install -E d3
+pnpm install -D -E @types/d3
 ```
 
 If there are no typings available, you can create your own `typings.d.ts` file and write some custom typings for your needs. They do not even have to be 100% complete; they can cover only the functionality which you use.
@@ -117,11 +117,11 @@ If there are no typings available, you can create your own `typings.d.ts` file a
 
 At Infinum, we recommend using [VSCode](https://code.visualstudio.com/) for Angular development, as it has a great integration with TypeScript and has some handy Angular plugins:
 
-- [Angular Language Service](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template)—IntelliSense in templates
-- [TSLint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint)
-- [stylelint](https://marketplace.visualstudio.com/items?itemName=shinnn.stylelint)
-- [Path Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense)
-- [Material Icon Theme](https://marketplace.visualstudio.com/items?itemName=PKief.material-icon-theme)
+* [Angular Language Service](https://marketplace.visualstudio.com/items?itemName=Angular.ng-template)—IntelliSense in templates
+* [TSLint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint)
+* [stylelint](https://marketplace.visualstudio.com/items?itemName=shinnn.stylelint)
+* [Path Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense)
+* [Material Icon Theme](https://marketplace.visualstudio.com/items?itemName=PKief.material-icon-theme)
 
 # [RxJS](https://github.com/ReactiveX/rxjs)
 
@@ -133,8 +133,8 @@ Please check out some RxJS tutorials if you are not familiar with Rx. Please not
 
 Here are some good introductory tutorials to get you started:
 
-- Academind—[Understanding RxJS](https://www.youtube.com/watch?v=T9wOu11uU6U&list=PL55RiY5tL51pHpagYcrN9ubNLVXF8rGVi) playlist
-- Interactive diagrams—[RxJS Marbles](https://rxmarbles.com/)
-  - this will help you a lot when trying to understand what specific operators do
-- Another tool to visualize the operators - [RxViz](https://rxviz.com/)
-- Angular documentation—[The RxJS Library](https://angular.io/guide/rx-library)
+* Academind—[Understanding RxJS](https://www.youtube.com/watch?v=T9wOu11uU6U\&list=PL55RiY5tL51pHpagYcrN9ubNLVXF8rGVi) playlist
+* Interactive diagrams—[RxJS Marbles](https://rxmarbles.com/)
+  * this will help you a lot when trying to understand what specific operators do
+* Another tool to visualize the operators - [RxViz](https://rxviz.com/)
+* Angular documentation—[The RxJS Library](https://angular.io/guide/rx-library)

--- a/Angular/Angular guidelines and best practices/DatX data store.md
+++ b/Angular/Angular guidelines and best practices/DatX data store.md
@@ -13,7 +13,7 @@ Apart from providing possible single source of truth for any shared data with a 
 Let's start by installing all DatX related dependencies we will need:
 
 ```
-npm i --save @datx/core @datx/jsonapi @datx/jsonapi-angular
+pnpm i -E @datx/core @datx/jsonapi @datx/jsonapi-angular
 ```
 
 Since we didn't include mobx (because it doesn't play nice with RxJS), we need to add a little boilerplate to work around that. First we need to instruct DatX not to use mobx, by adding `'@datx/core/disable-mobx'` before App bootstrap:
@@ -60,7 +60,7 @@ Lastly, we bypass `@datx/core/disable-mobx` related import warning by adding its
 
 ## Defining models and their relationships
 
-This topic is heavily described in the resources above, please refer to them. By convention, you can put all models in `src/app/models` directory and collections to `src/app/collections` of your Angular project. Once you are finished describing all _Resource Objects_ you can move to the next section, just remember that you will most likely want to use _jsonapiAngular_ so that you can work with observables when calling async methods on models.
+This topic is heavily described in the resources above, please refer to them. By convention, you can put all models in `src/app/models` directory and collections to `src/app/collections` of your Angular project. Once you are finished describing all *Resource Objects* you can move to the next section, just remember that you will most likely want to use *jsonapiAngular* so that you can work with observables when calling async methods on models.
 
 ## Store setup and injection
 
@@ -119,7 +119,7 @@ export class ExampleService {
 }
 ```
 
-When testing consumers of APP_COLLECTION, just inject the collection under the same token again, as with any other dependency:
+When testing consumers of APP\_COLLECTION, just inject the collection under the same token again, as with any other dependency:
 
 ```ts
 // example.service.spec.ts

--- a/Changesets.md
+++ b/Changesets.md
@@ -4,11 +4,11 @@
 
 [`changesets`](https://github.com/changesets/changesets) offer a solution to the problem of organizing package releases and grouping changes effectively. Here's why you should consider using changesets:
 
-- **Capture Changes at the Right Time**: Changesets allow contributors to document changes during pull request (PR) submission, ensuring up-to-date and comprehensive information.
-- **Distinct Intent to Change**: Changesets separate the intent to change from changelogs and version bumps, providing clear versioning and changelog details.
-- **Efficient Versioning Process**: Add changesets in PRs, then combine them for version bumps, streamlining reviews and boosting confidence in versioning decisions.
-- **Streamlined Tooling**: Changesets come with CLI-generated tools, automated versioning, and surfaced changesets in PRs, reducing manual effort.
-- **Mono-repo Compatibility**: Designed for monorepos, changesets handle interdependencies and ensure compatibility, benefiting single-package repositories as well.
+* **Capture Changes at the Right Time**: Changesets allow contributors to document changes during pull request (PR) submission, ensuring up-to-date and comprehensive information.
+* **Distinct Intent to Change**: Changesets separate the intent to change from changelogs and version bumps, providing clear versioning and changelog details.
+* **Efficient Versioning Process**: Add changesets in PRs, then combine them for version bumps, streamlining reviews and boosting confidence in versioning decisions.
+* **Streamlined Tooling**: Changesets come with CLI-generated tools, automated versioning, and surfaced changesets in PRs, reducing manual effort.
+* **Mono-repo Compatibility**: Designed for monorepos, changesets handle interdependencies and ensure compatibility, benefiting single-package repositories as well.
 
 Find more information about changesets in the [official documentation](http://github.com/changesets/changesets)
 
@@ -19,20 +19,20 @@ Find more information about changesets in the [official documentation](http://gi
 First, install the @changesets/cli package in the repository where you want to use changesets:
 
 ```bash
-npm install -D @changesets/cli
+pnpm install -D -E @changesets/cli
 ```
 
 Once installed, initialize the repository to use changesets:
 
 ```bash
-npx changeset init
+pnpm changeset init
 ```
 
 ### Github Actions
 
 Although changesets can function without continuous integration (CI), it's recommended to use it with a CI system to automate versioning and publishing. You can utilize the [Github Action](https://github.com/changesets/action) provided by the changesets team.
 
-To use the action, create a `.github/workflows/release.yml` file. Follow the instructions under the [With Publishing](https://github.com/changesets/action#with-publishing) section in the documentation, with minor adjustments. This flow updates the versions of changed packages and publishes them to npm.
+To use the action, create a `.github/workflows/release.yml` file. Follow the instructions under the [With Publishing](https://github.com/changesets/action#with-publishing) section in the documentation, with minor adjustments. This flow updates the versions of changed packages and publishes them to npm registry.
 
 ```yml
 name: Release
@@ -51,32 +51,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # Make sure to use correct Node.js version for your project
+      # Corepack makes sure to use correct Node.js version for your project, it requires having "engines" specified in package.json file
+      # Read more about Corepack and advanced dependencies caching at: https://infinum.com/handbook/frontend/node/managing-node-npm-versions
+      - name: 🗃️ Enable corepack
+        run: corepack enable
+        shell: bash
+
       - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          cache: 'npm'
-          # Use the node version specified in the .node-version file if it exists
-          node-version-file: '.node-version'
-          # otherwise fall back to the version specified here
-          # node-version: '18.x'
+        uses: actions/setup-node@v4
 
       - name: Install Dependencies
-        run: npm ci
+        run: pnpm install --prod --frozen-lockfile
 
-      - name: Create Release Pull Request or Publish to npm
+      - name: Create Release Pull Request or Publish to npm registry
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: npm run publish
+          publish: pnpm ci:publish
           # if your repository is using conventional commits, you should use the following option (the message can be customized)
           # commit: 'ci: version packages'
         env:
           # GITHUB_TOKEN is required for creating a pull request and will be provided by the Github Action automatically
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # NPM_TOKEN is required for publishing to npm and needs to be provided manually
+          # NPM_TOKEN is required for publishing to registry and needs to be provided manually
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # This step will push tags to the repository after the packages are published and will create a new release on Github
@@ -87,14 +86,14 @@ jobs:
 
 Before using the action, ensure the following checklist is complete:
 
-- Ask your TL, TD, or PE to add the NPM_TOKEN to the repository secrets.
-- Confirm that the `package.json` file has the `publish` script: `"publish": "changeset publish"`.
-- Ensure the package is built before publishing it to npm (optional).
-- Verify that the Node version is correct.
-- Confirm that the branch name is accurate.
-- Ensure the `package.json` file has the `main` field.
-- Verify that only relevant items will be published to npm (e.g., no `__tests__` folder) by adding [a `.npmignore` file or using a files field in the `package.json` file](https://docs.npmjs.com/cli/v9/using-npm/developers#testing-whether-your-npmignore-or-files-config-works).
-- Confirm that the `package.json` file has the `repository` field (with `directory` for monorepos).
+* Ask your TL, TD, or PE to add the NPM\_TOKEN to the repository secrets.
+* Confirm that the `package.json` file has the `publish` script: `"ci:publish": "changeset publish"`.
+* Ensure the package is built before publishing it to npm (optional).
+* Verify that the Node version is correct.
+* Confirm that the branch name is accurate.
+* Ensure the `package.json` file has the `main` field.
+* Verify that only relevant items will be published to the registry (e.g., no `__tests__` folder) by adding [a `.npmignore` file or using a files field in the `package.json` file](https://www.npmjs.com/package/npm-packlist) and running [pnpm pack](https://pnpm.io/cli/pack) command.
+* Confirm that the `package.json` file has the `repository` field (with `directory` for monorepos).
 
 ### Changeset Bot
 
@@ -112,9 +111,9 @@ When you finish making changes, create a PR as usual. The bot will add a comment
 This is a patch release because of a bug fix.
 ```
 
-Once the PR is merged, the GitHub Action will create a new release, bump the version, and publish the package to npm. It removes the generated changesets, preparing for the next release.
+Once the PR is merged, the GitHub Action will create a new release, bump the version, and publish the package to registry. It removes the generated changesets, preparing for the next release.
 
-When a release is ready, responsible person will merge the PR and the Github Action will publish the package to npm. It will also create a new tag and a Github release.
+When a release is ready, responsible person will merge the PR and the Github Action will publish the package to registry. It will also create a new tag and a Github release.
 
 ## Pre-releases
 
@@ -125,7 +124,7 @@ Changesets can be used to create pre-releases. It is not as easy as regular rele
 First thing you need to do is to enter the pre-release mode:
 
 ```bash
-npx changeset pre <tag>
+pnpm changeset pre <tag>
 ```
 
 Most often for `<tag>` we will use `beta` but you can use any tag you want - e.g. `alpha`, `rc`, `next`, etc.
@@ -133,7 +132,7 @@ Most often for `<tag>` we will use `beta` but you can use any tag you want - e.g
 As a result, a new file will be created in the `.changeset` folder. Next thing to do is to update the version of the package you want to release. You can do that by using the `changeset version` command:
 
 ```bash
-npx changeset version
+pnpm changeset version
 ```
 
 Now, we need to commit the version change and the changeset file:
@@ -146,10 +145,10 @@ git commit -m "chore: release <tag>"
 Once commited, we can publish the package:
 
 ```bash
-npx changeset publish
+pnpm changeset publish
 ```
 
-> IMPORTANT: Make sure to use `changeset publish` command instead of `npm publish` because `npm` does not know that we are in prerelease mode.
+> IMPORTANT: Make sure to use `changeset publish` command instead of `pnpm publish` because `pnpm` does not know that we are in prerelease mode.
 
 After publishing, we can push the tag to the origin and create a new release manually.
 
@@ -160,7 +159,7 @@ git push --follow-tags
 Once you are done with the pre-release, you can exit the pre-release mode:
 
 ```bash
-npx changeset exit pre
+pnpm changeset exit pre
 ```
 
 This will create changes in your code so make sure to also commit them.
@@ -174,11 +173,11 @@ git commit -m "chore: exit pre-release mode"
 
 Changesets are already implemented in a few repositories. Check them out to see how they work:
 
-- [js-linters](https://github.com/infinum/js-linters)
-- [polyglot-cli](https://github.com/infinum/js-polyglot-cli)
+* [js-linters](https://github.com/infinum/js-linters)
+* [polyglot-cli](https://github.com/infinum/js-polyglot-cli)
 
 ## Resources
 
-- [Changesets](https://github.com/changesets/changesets)
-- [Changeset Bot](https://github.com/changesets/bot)
-- [Changesets Github Action](https://github.com/changesets/action)
+* [Changesets](https://github.com/changesets/changesets)
+* [Changeset Bot](https://github.com/changesets/bot)
+* [Changesets Github Action](https://github.com/changesets/action)

--- a/Code Quality/Tools.md
+++ b/Code Quality/Tools.md
@@ -10,13 +10,10 @@ No matter which code quality tools we use, git hooks are a great way to run thos
 
 Follow [usage](https://github.com/typicode/husky#usage) guidelines for installing Husky and add hooks.
 
-After running all commands described in [usage](https://github.com/typicode/husky#usage) chapter, you should have `.husky` folder with hooks folder inside. For example, if you created `pre-commit` hook which runs `npm test` command, you should have `pre-commit` file in `.husky` folder, with following content
+After running all commands described in [usage](https://github.com/typicode/husky#usage) chapter, you should have `.husky` folder with hooks folder inside. For example, if you created `pre-commit` hook which runs `pnpm test` command, you should have `pre-commit` file in `.husky` folder, with following content
 
 ```sh
-# .husky/pre-commit
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-npm test
+pnpm test
 ```
 
 In this example, if you try pushing and the tests fail, code will not get pushed to the remote. We do not necessarily recommend running tests on push, it is just an example (there are better ways to run automated tests using a proper CI/CD set-up).
@@ -26,11 +23,7 @@ Most of our code quality tools are run on either `pre-commit` or `pre-push` hook
 Note: By design `husky install` must be run in the same directory as `.git`. You can change directory in your `prepare` script. Also, you will need to change directory in your hooks. For example, if you have `frontend` directory where you want to run `pre-commit` hook, your hook file might look like following
 
 ```sh
-# .husky/pre-commit
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-cd frontend && npx lint-staged
-
+cd frontend && pnpm lint-staged
 ```
 
 For more use cases please check [Husky documentation](https://typicode.github.io/husky/#/).
@@ -60,11 +53,7 @@ Here is an example which runs `prettier` and `eslint` on all staged `.js` and `.
 ```
 
 ```sh
-# .husky/pre-commit
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx lint-staged
+pnpm lint-staged
 ```
 
 What `lint-staged` does is it matches files to `glob` patterns and passes the list of files as an argument to scripts. Tooling developers should ensure that their scripts can receive the list of files in the correct format. Most common tools like eslint, tslint, stylelint and others are compatible with the way `lint-staged` passes the list of files.
@@ -77,7 +66,7 @@ Check the following chapters for specifics about Prettier, ESLint and Stylelint.
 
 ![Bikeshedding](/img/work.png)
 
-_Source: [XKCD](https://xkcd.com/1741/)_
+*Source: [XKCD](https://xkcd.com/1741/)*
 
 Many people are very passionate about the way they format their code. While we appreciate everyone's opinion, we believe it is best to leave this bikeshedding to automated tooling. It might not format the code in a way that is satisfying to everyone, but it will be consistent across projects and, more importantly, it will format the code written by different people in the same way. This also eliminates discussions around formatting.
 
@@ -182,9 +171,9 @@ Even though [TSLint](https://palantir.github.io/tslint/) is deprecated, it is st
 
 Infinum created various rulesets for ESLint and TSLint which you can check out [here](https://github.com/infinum/js-linters). We encourage you to use some of these presets, as per your needs:
 
-- [Base ESLint config](https://github.com/infinum/js-linters/tree/master/packages/eslint-config-core-ts)
-- [React ESLint config](https://github.com/infinum/js-linters/tree/master/packages/eslint-config-react-ts)
-- [Angular ESLint config](https://github.com/infinum/js-linters/tree/master/packages/eslint-config-angular-ts)
+* [Base ESLint config](https://github.com/infinum/js-linters/tree/master/packages/eslint-config-core-ts)
+* [React ESLint config](https://github.com/infinum/js-linters/tree/master/packages/eslint-config-react-ts)
+* [Angular ESLint config](https://github.com/infinum/js-linters/tree/master/packages/eslint-config-angular-ts)
 
 ### Stylelint
 
@@ -218,7 +207,7 @@ Here is the complete example which runs TypeScript compilation check on all file
 {
   "scripts": {
     "prepare": "husky install",
-    "tsc": "concurrently \"npm run tsc:app\" \"npm run tsc:spec\"",
+    "tsc": "concurrently \"pnpm tsc:app\" \"pnpm tsc:spec\"",
     "tsc:app": "tsc --noEmit -p ./src/tsconfig.app.json",
     "tsc:spec": "tsc --noEmit -p ./src/tsconfig.spec.json"
   }
@@ -244,11 +233,7 @@ Here is the complete example which runs TypeScript compilation check on all file
 ```
 
 ```sh
-# .husky/pre-commit
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
-npm run tsc && npx lint-staged --config .lintstagedrc.json && prettier --write
+pnpm tsc && pnpm lint-staged --config .lintstagedrc.json
 ```
 
 ```js
@@ -274,12 +259,12 @@ npm run tsc && npx lint-staged --config .lintstagedrc.json && prettier --write
 For this example, you will have to install the following `devDependencies`:
 
 ```bash
-npm i -D concurrently husky lint-staged stylelint stylelint-prettier prettier tslint-config-prettier
+pnpm i -D -E concurrently husky lint-staged stylelint stylelint-prettier prettier tslint-config-prettier
 ```
 
 Some notes:
 
-- it is important to run `tsc` on all files because changes in staged files can affect compilation of unmodified files
-- `tsc` is run on both the application `tsconfig` files and tests `tsconfig` files
-- `concurrently` speeds up things by running tsc checks in parallel
-- `prettier --write` is run separately for `.ts` and other files in order to prevent any possible race conditions before running TSLint (via `lint:ng`) and Prettier
+* it is important to run `tsc` on all files because changes in staged files can affect compilation of unmodified files
+* `tsc` is run on both the application `tsconfig` files and tests `tsconfig` files
+* `concurrently` speeds up things by running tsc checks in parallel
+* `prettier --write` is run separately for `.ts` and other files in order to prevent any possible race conditions before running TSLint (via `lint:ng`) and Prettier

--- a/Node/Managing Node-NPM versions.md
+++ b/Node/Managing Node-NPM versions.md
@@ -49,13 +49,14 @@ Considering previously mentioned options, there is no particular advantage why y
 
 #### Specifying version in package.json
 
-You can specify the version of node that your stuff works on by providing Node versions in package.json. If you don't specify this, it means any version will do. It is also possible to specify version of `npm` as it is possible that even the minor version updates cause breaking changes.
+You can specify the version of node that your stuff works on by providing Node versions in package.json. If you don't specify this, it means any version will do. It is also possible to specify version of `pnpm` as it is possible that even the minor version updates cause breaking changes.
 
 ```json
 {
+  "packageManager": "pnpm@9.0.6",
   "engines": {
     "node": ">= 18.12",
-    "npm": "8.19.3"
+    "pnpm": "pnpm@9.0.6"
   }
 }
 ```

--- a/Node/Node logging.md
+++ b/Node/Node logging.md
@@ -4,9 +4,9 @@ Infinum uses [Graylog](https://www.graylog.org/) to log all requests that are pr
 
 ### Setup
 
-Install the gelf-pro package via npm/yarn:
+Install the gelf-pro package:
 
-```npm install -s gelf-pro```
+`pnpm install -E gelf-pro`
 
 ### Configuration
 
@@ -68,6 +68,7 @@ log.error('Something bad has happened')
 ### Documentation
 
 Read more about logging here:
+
 * [gelf-pro JS API](https://github.com/kkamkou/node-gelf-pro)
 * [Graylog & GELF](http://docs.graylog.org/en/latest/pages/gelf.html)
 * [loglevel](https://github.com/pimterry/loglevel)

--- a/React Native/Project setup.md
+++ b/React Native/Project setup.md
@@ -1,8 +1,7 @@
 When starting a new React Native project there are two possible options / tools which can be used to set up your project.
 
- 1. [Expo](https://expo.io/), which is generally used if you need quick & easy solution. Even though it can speed up the whole process of setup and development of RN app, it comes with set of options and [limitations](https://docs.expo.io/introduction/why-not-expo/) which can be a dealbreaker for your project needs.
- 2. [React Native CLI](https://github.com/react-native-community/cli) represents official RN community tool for building and managing RN projects.
-
+1. [Expo](https://expo.io/), which is generally used if you need quick & easy solution. Even though it can speed up the whole process of setup and development of RN app, it comes with set of options and [limitations](https://docs.expo.io/introduction/why-not-expo/) which can be a dealbreaker for your project needs.
+2. [React Native CLI](https://github.com/react-native-community/cli) represents official RN community tool for building and managing RN projects.
 
 ## Setting up the development environment ( React Native CLI)
 
@@ -10,42 +9,41 @@ When starting a new React Native project there are two possible options / tools 
 
 When creating a new RN project check CLI [commands](https://github.com/react-native-community/cli/blob/master/docs/commands.md) to get familiar with all options.
 
-Generally, most of our projects use `typescript` and `npm` as package manager. This means that for creation & initialization of a new project you need to use command:
+Generally, most of our projects use `typescript` and `pnpm` as package manager. This means that for creation & initialization of a new project you need to use command:
 
-````sh
-npx react-native init AwesomeProjectName --template react-native-template-typescript --npm
-````
-
-***Note:*** If previous command fails, it's possible that `react-native-template-typescript` is deprecated or there are some major changes to CLI. In that case, please contact someone from Javascript team to update the chapter.
+```sh
+pnpx create-expo-app@latest AwesomeProjectName
+```
 
 ### Github repository
+
 Since the creation of github repositories is limited to admins only, contact one of the Javascript team leads to create a repository for you.
 Once you've got your repository make sure to update your `.gitignore`.
 Don't forget to add `README.md` which should consist of:
 
- 1. Application name and logo
- 2. **Toc** (Table of Content)
- 3. **Setup** - add basic description of how to initialize project and install dependencies
- 4. **Development** - description of all commands and configurations needed to start developing and running the application on real device / simulator
- 5. **Versioning manifest** - notes on semver versioning
- 6. **Building** - how to build the app for both platforms
- 7. **Notes** - project specifics (gotchas, known bugs in used libraries, todos etc.)
+1. Application name and logo
+2. **Toc** (Table of Content)
+3. **Setup** - add basic description of how to initialize project and install dependencies
+4. **Development** - description of all commands and configurations needed to start developing and running the application on real device / simulator
+5. **Versioning manifest** - notes on semver versioning
+6. **Building** - how to build the app for both platforms
+7. **Notes** - project specifics (gotchas, known bugs in used libraries, todos etc.)
 
 ### Project structure
 
 To get started with project structure please check our official [React handbook](https://infinum.com/handbook/books/frontend/javascript/react).
 Since there are some semantic differences and domain specifics between React and React Native application some of the naming is different.
 For example, in RN we don't have concept of pages. RN uses screens as it's top level views (building elements), therefore we will have `screens` directory instead of `pages`.
-Also, navigation in RN represents more than a mere routing system. It makes the applications base and holds informations on the structure and it's configuration. Therefore, we use define `navigation` directory inside project root. Check [navigation chapter](todo) for detailed informations on this.
+Also, navigation in RN represents more than a mere routing system. It makes the applications base and holds informations on the structure and it's configuration. Therefore, we use define `navigation` directory inside project root. Check [navigation chapter](./navigation) for detailed informations on this.
 
 ### Dependencies
 
 Since RN uses the React ecosystem, we can reuse most of it's development dependencies like linters, prettier configurations etc.
 
-
 ## Platform specifics
 
 ### Android
+
 Android uses Gradle as a build and dependency management system. For that reason all android specifics configurations, like application version, minimal supported SDK, flavors etc. are configured inside application gradle file.
 To get familiar with android (gradle) configuration please check our official [android handbook chapter](https://infinum.com/handbook/books/android/project-structure/gradle-build-system).
 

--- a/React Native/Styling.md
+++ b/React Native/Styling.md
@@ -53,7 +53,7 @@ const page = StyleSheet.create({
 
 More on the `Stylesheet API` can be found on:
 
-[https://reactnative.dev/docs/stylesheet](https://reactnative.dev/docs/stylesheet)
+<https://reactnative.dev/docs/stylesheet>
 
 Important thing to recognize here is that all measurement values are written as numbers, not pixels like we are used to in web development. That is because all dimensions in React Native are unitless, and represent density-independent pixels. Setting dimensions this way is common for components that should always render at exactly the same size, regardless of screen dimensions.
 
@@ -62,7 +62,7 @@ Important thing to recognize here is that all measurement values are written as 
 RN uses Flexbox algorithm for defining the component layout. Flexbox properties on RN are practicly identical to web with one difference and that is `flexDirection`. Default value for `flexDirection` property in RN is `column`, where on web it is `row`.
 
 More on Flexbox layout can be found on:
-[https://reactnative.dev/docs/flexbox](https://reactnative.dev/docs/flexbox)
+<https://reactnative.dev/docs/flexbox>
 
 ## Styled-components
 
@@ -83,7 +83,7 @@ Next paragraphs inside the section are related to configuration & usage of `styl
 
 #### Installation
 
-`npm install --save styled-components` or `yarn add styled-components`
+`pnpm install -E styled-components`
 
 #### Usage
 
@@ -219,6 +219,4 @@ export const Circle: React.FunctionComponent = () => {
 #### Theming
 
 Theming in RN with `styled-components` is identical to React.
-More on theming can be found on:
-[link to React guide] // TODO
-[https://styled-components.com/docs/advanced#theming](https://styled-components.com/docs/advanced#theming)
+<https://styled-components.com/docs/advanced#theming>

--- a/React Native/Testing.md
+++ b/React Native/Testing.md
@@ -5,22 +5,22 @@ my video tutorial https://www.youtube.com/watch?v=AhH5xFPwNHg.
 
 By default - RN ships with Jest testing library that doesn’t require additional setup and works out of the box. To run tests - use:
 
-`npm run test`
+`pnpm test`
 
 But default test which can be found in **tests**/ folder is too simple and for more complicated and useful tests
 we will require another library - https://github.com/callstack/react-native-testing-library (which replaces Enzyme if you’re familiar with that)
 
-`npm install --save-dev @testing-library/react-native`
+`pnpm install -D -E @testing-library/react-native`
 
 To have more matchers we can also install https://github.com/testing-library/jest-native
 
-`npm install --save-dev @testing-library/jest-native`
+`pnpm install -D -E @testing-library/jest-native`
 
 ### Testing Styled components
 
 ***!! NOT WORKING in ("jest-styled-components": "7.0.3") !! https://github.com/styled-components/jest-styled-components/issues/294***
 
-As styled-components is our RN way of styling - we need to know how to test it. But not now :\
+As styled-components is our RN way of styling - we need to know how to test it. But not now :\\
 
 ### Mocking native modules
 

--- a/React/Chakra UI.md
+++ b/React/Chakra UI.md
@@ -5,7 +5,7 @@ Chakra UI is a simple, modular and accessible component library that gives you t
 ### Installation:
 
 ```
-npm i @chakra-ui/react @emotion/react @emotion/styled framer-motion
+pnpm i -E @chakra-ui/react @emotion/react @emotion/styled framer-motion
 ```
 
 For more about setup read [docs](https://chakra-ui.com/docs/getting-started)
@@ -33,8 +33,8 @@ export default App;
 
 Note:
 
-- For Next.js, you need to set this up in `pages/_app.tsx`
-- For Create React App, you need to set this up in `index.tsx`
+* For Next.js, you need to set this up in `pages/_app.tsx`
+* For Create React App, you need to set this up in `index.tsx`
 
 For including `<CSSReset />` just add `resetCSS` prop to `<ChakraProvider>`
 
@@ -87,9 +87,9 @@ Example:
 
 ### The `__css` prop
 
-`__css` prop is similar to `sx` but it is designed __ONLY__ for internal use (hence the private prefix `__`).
+`__css` prop is similar to `sx` but it is designed **ONLY** for internal use (hence the private prefix `__`).
 The main difference is that `__css` prop will be merged before `sx` prop ([github](https://github.com/chakra-ui/chakra-ui/blob/085891be806b855af90b86367f5b26e8151c3ff5/packages/system/src/system.ts#L106)).
-We should __ONLY__ use it for building primitive `core` components.
+We should **ONLY** use it for building primitive `core` components.
 
 ```jsx
 import { chakra, HTMLChakraProps, ThemingProps, useStyleConfig } from '@chakra-ui/react';
@@ -155,7 +155,7 @@ const Button = chakra("button", {
 });
 ```
 
-__Update (14.05.2021.)__
+**Update (14.05.2021.)**
 
 Previously we had this example:
 
@@ -256,8 +256,8 @@ The `as` prop is a feature that all Chakra UI components have and it allows you 
 
 `as` prop (`polymorphic prop`) is a feature of emotion borrowed from styled-components
 
-- [emotion as prop](https://emotion.sh/docs/styled#as-prop)
-- [styled-components polymorphic prop](https://styled-components.com/docs/api#as-polymorphic-prop)
+* [emotion as prop](https://emotion.sh/docs/styled#as-prop)
+* [styled-components polymorphic prop](https://styled-components.com/docs/api#as-polymorphic-prop)
 
 It allows us to use all of the `Button` props and all of the `a` props without having to wrap the `Button` in an `a` component.
 
@@ -278,9 +278,9 @@ The `as` prop can also be another React component:
 </Button>
 ```
 
-- `Button` will be rendered as `Link` component
-- `Link` props will become available on `Button`
-- `Link` and `Button` styles will be combined
+* `Button` will be rendered as `Link` component
+* `Link` props will become available on `Button`
+* `Link` and `Button` styles will be combined
 
 For more info about `as` prop read [docs](https://chakra-ui.com/docs/features/style-props#the-as-prop)
 
@@ -351,10 +351,10 @@ Then in `props` we have access button props, `theme` object and `colorMode`.
 
 Chakra has a whole pallet of useful helpers:
 
-- `mode(lightMode, darkMode)(props)` function is the same as `colorMode === "dark" ? darkMode : lightMode`.
-- `orient` define `vertical` and `horizontal` style for component: `<Divider orientation="horizontal | vertical" />`
-- `transparentize` helper to make a color transparent `transparentize('blue.100', 0.3)`
-- `darken` darken a specified color `darken('blue.100', 0.5)` (there is also `lighten`, `blacken`, `whiten`)
+* `mode(lightMode, darkMode)(props)` function is the same as `colorMode === "dark" ? darkMode : lightMode`.
+* `orient` define `vertical` and `horizontal` style for component: `<Divider orientation="horizontal | vertical" />`
+* `transparentize` helper to make a color transparent `transparentize('blue.100', 0.3)`
+* `darken` darken a specified color `darken('blue.100', 0.5)` (there is also `lighten`, `blacken`, `whiten`)
 
 For more about `theme-tools` check out [github](https://github.com/chakra-ui/chakra-ui/tree/develop/packages/theme-tools/src)
 
@@ -489,10 +489,10 @@ export const breakpoints = {
 
 Here's how to interpret this syntax:
 
-- `base`: From `0em` upwards
-- `md`: From `48em` upwards
-- `lg`: From `62em` upwards
-- `xl`: From `80em` upwards
+* `base`: From `0em` upwards
+* `md`: From `48em` upwards
+* `lg`: From `62em` upwards
+* `xl`: From `80em` upwards
 
 For responsive styles, array or object syntax can be used.
 
@@ -522,8 +522,8 @@ Array and Object syntax work for every style prop in the theme specification, wh
 
 To create custom breakpoints read [docs](https://chakra-ui.com/docs/features/responsive-styles#customizing-breakpoints).
 
-_NOTE: there is an issue with having `strict: false` in tsconfig when using `createBreakpoints`.
-Error that breaks the build: `Type '(() => string) & (() => string)' is not assignable to type 'string'`. Current workaround is to add `strictNullChecks: true` to tsconfig. ([github issue](https://github.com/chakra-ui/chakra-ui/issues/3372))_
+*NOTE: there is an issue with having `strict: false` in tsconfig when using `createBreakpoints`.
+Error that breaks the build: `Type '(() => string) & (() => string)' is not assignable to type 'string'`. Current workaround is to add `strictNullChecks: true` to tsconfig. ([github issue](https://github.com/chakra-ui/chakra-ui/issues/3372))*
 
 For more about responsive styles read [styled-system responsive styles docs](https://styled-system.com/responsive-styles/)
 
@@ -534,10 +534,10 @@ Chakra UI has a specific API for styling components. Most components have defaul
 Components styles are defined in `theme/components/<component-name>.ts`
 Each component style will export these objects:
 
-- `baseStyles`
-- `sizes`
-- `variants`
-- `defaultProps`
+* `baseStyles`
+* `sizes`
+* `variants`
+* `defaultProps`
 
 `baseStyle` are styles that all button types share.
 
@@ -605,10 +605,10 @@ const sizes: { [size: string]: StyleObjectOrFn } = {
 
 Naming used for sizes:
 
-- `lg`
-- `md`
-- `sm`
-- `xs`
+* `lg`
+* `md`
+* `sm`
+* `xs`
 
 `defaultProps` are default values for `size` and `variant`
 
@@ -677,28 +677,28 @@ const ReactSelect = {
 
 Keys in `baseStyle` can be one of:
 
-- clearIndicator
-- container
-- control
-- dropdownIndicator
-- group
-- groupHeading
-- indicatorsContainer
-- indicatorSeparator
-- input
-- loadingIndicator
-- loadingMessage
-- menu
-- menuList
-- menuPortal
-- multiValue
-- multiValueLabel
-- multiValueRemove
-- noOptionsMessage
-- option
-- placeholder
-- singleValue
-- valueContainer
+* clearIndicator
+* container
+* control
+* dropdownIndicator
+* group
+* groupHeading
+* indicatorsContainer
+* indicatorSeparator
+* input
+* loadingIndicator
+* loadingMessage
+* menu
+* menuList
+* menuPortal
+* multiValue
+* multiValueLabel
+* multiValueRemove
+* noOptionsMessage
+* option
+* placeholder
+* singleValue
+* valueContainer
 
 Reade more about react-select style objects in [docs](https://react-select.com/styles#style-object).
 

--- a/React/Recipes/Datx Store Provider.md
+++ b/React/Recipes/Datx Store Provider.md
@@ -30,10 +30,10 @@ If you are working with a JSON:API, `datx` can handle that too - hello `datx-jso
 
 If you want to follow along completely, here is a list of all needed dependencies:
 
-- [datx](https://datx.dev/)
-- [dequal](https://github.com/lukeed/dequal)
-- [mobx](https://mobx.js.org/README.html)
-- [swr](https://swr.vercel.app/)
+* [datx](https://datx.dev/)
+* [dequal](https://github.com/lukeed/dequal)
+* [mobx](https://mobx.js.org/README.html)
+* [swr](https://swr.vercel.app/)
 
 After datx store is initialized, we will create a datx context that will enable us to use DatX in our web application. For the context, we will need a provider - `DatxProvider`and a hook - `useDatx`.
 
@@ -65,13 +65,13 @@ export const DatxProvider: FC<IDatxProviderProps> = ({ client, children }) => (
 
 Let's break things up into sections:
 
-- `DatxContext` is just a new context that will be used for our datx store
+* `DatxContext` is just a new context that will be used for our datx store
 
-- `Client` is our datx store
+* `Client` is our datx store
 
-- `DatxProvider` is a wrapper that will serve the context along with some default swr config
+* `DatxProvider` is a wrapper that will serve the context along with some default swr config
 
-- `SWRConfig` is a provider for swr config defaults. Currently, this is empty but if there is a config that should be used for every swr hook, this is a good place to change that.
+* `SWRConfig` is a provider for swr config defaults. Currently, this is empty but if there is a config that should be used for every swr hook, this is a good place to change that.
 
 Once the provider is created, wrap your whole application inside the created provider. In React application, you can do this in `index.ts` file and in Next.js application, you can do this in `_app.ts` file.
 
@@ -97,7 +97,7 @@ export function useDatx() {
 }
 ```
 
-This hook will throw an error if `useDatx` is called without `DatxProvider`. _If you followed the previous step, this will be already implemented in a `index` or `_app` file._
+This hook will throw an error if `useDatx` is called without `DatxProvider`. *If you followed the previous step, this will be already implemented in a `index` or `_app` file.*
 
 ## Usage
 
@@ -270,7 +270,7 @@ config.transformRequest = (opts: ICollectionFetchOpts) => {
 Mentioned methods `apify` and `deapify` are using `lodash` methods under the hood. For that you'll need to install `lodash` (or only the specific lodash methods) as well:
 
 ```bash
-npm install lodash
+pnpm install -E lodash
 ```
 
 ```ts

--- a/React/Recipes/Error Handling.md
+++ b/React/Recipes/Error Handling.md
@@ -60,4 +60,4 @@ const ErrorFallback = (error, info, clearError) => {
 
 1. [Bugsnag with Next.js example](https://github.com/bugsnag/bugsnag-js/tree/master/examples/js/nextjs)
 2. [Use react-error-boundary to handle errors in React](https://kentcdodds.com/blog/use-react-error-boundary-to-handle-errors-in-react)
-3. If you don't have Bugsnag you can use this npm module [react-error-boundary](https://www.npmjs.com/package/react-error-boundary)
+3. If you don't have Bugsnag you can use this dependency instead [react-error-boundary](https://www.npmjs.com/package/react-error-boundary)

--- a/React/Testing/Best practices.md
+++ b/React/Testing/Best practices.md
@@ -9,7 +9,7 @@ If you want to see more practical usage, [here](https://www.youtube.com/watch?v=
 First of all, install Jest:
 
 ```bash
-npm install --save-dev jest @types/jest
+pnpm install -D -E jest @types/jest
 ```
 
 Add a test script to `package.json`:
@@ -20,8 +20,8 @@ Add a test script to `package.json`:
 
     // optional?
     "test:ci": "jest --ci --coverage",
-    "test:update": "npm run test -- --u",
-    "test:watch": "npm run test -- --watch",
+    "test:update": "pnpm test -- --u",
+    "test:watch": "pnpm test -- --watch",
     // ...other scripts
   }
 ```
@@ -31,7 +31,7 @@ Create the `jest.config.js` file in the project root and follow the instructions
 Next, install `react-test-library`:
 
 ```bash
-npm i --save-dev @testing-library/react
+pnpm i -D -E @testing-library/react
 ```
 
 ### User events
@@ -39,7 +39,7 @@ npm i --save-dev @testing-library/react
 Use [testing-library/user-event](https://github.com/testing-library/user-event) for mocking events:
 
 ```bash
-npm install --save-dev @testing-library/user-event
+pnpm install -D -E @testing-library/user-event
 ```
 
 ### Testing hooks
@@ -47,7 +47,7 @@ npm install --save-dev @testing-library/user-event
 Use [react-hooks-testing-library](https://github.com/testing-library/react-hooks-testing-library) for testing hooks:
 
 ```bash
-npm install --save-dev @testing-library/react-hooks
+pnpm install -D -E @testing-library/react-hooks
 ```
 
 ## Utils
@@ -197,20 +197,20 @@ Based on [the Guiding Principles](https://testing-library.com/docs/guiding-princ
 
 1. Queries Accessible to Everyone queries that reflect the experience of visual/mouse users as well as those that use assistive technology
 
-   - `getByRole` - this can be used to query every element that is exposed in the accessibility tree. With the `name` option you can filter the returned elements by their accessible name. This should be your top preference for just about everything. There's not much you can't get with this (if you can't, it's possible your UI is inaccessible). Most often, this will be used with the name option like so: `getByRole('button', {name: /submit/i})`. Check the [list of roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#roles).
-   - `getByLabelText` - only really good for form fields, but this is the number one method a user finds those elements, so it should be your top preference.
-   - `getByPlaceholderText` - a placeholder is not a substitute for a label. But if that's all you have, then it's better than alternatives.
-   - `getByText` - not useful for forms, but this is the number 1 method a user finds most non-interactive elements (like divs and spans).
-   - `getByDisplayValue` - the current value of a form element can be useful when navigating a page with filled-in values.
+   * `getByRole` - this can be used to query every element that is exposed in the accessibility tree. With the `name` option you can filter the returned elements by their accessible name. This should be your top preference for just about everything. There's not much you can't get with this (if you can't, it's possible your UI is inaccessible). Most often, this will be used with the name option like so: `getByRole('button', {name: /submit/i})`. Check the [list of roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques#roles).
+   * `getByLabelText` - only really good for form fields, but this is the number one method a user finds those elements, so it should be your top preference.
+   * `getByPlaceholderText` - a placeholder is not a substitute for a label. But if that's all you have, then it's better than alternatives.
+   * `getByText` - not useful for forms, but this is the number 1 method a user finds most non-interactive elements (like divs and spans).
+   * `getByDisplayValue` - the current value of a form element can be useful when navigating a page with filled-in values.
 
-1. Semantic Queries HTML5 and ARIA compliant selectors. Note that the user experience of interacting with these attributes varies greatly across browsers and assistive technology.
+2. Semantic Queries HTML5 and ARIA compliant selectors. Note that the user experience of interacting with these attributes varies greatly across browsers and assistive technology.
 
-   - `getByAltText` - if your element is one which supports `alt` text (`img`, `area`, and `input`), then you can use this to find that element
-   - `getByTitle` - the title attribute is not consistently read by screenreaders, and is not visible by default for sighted users
+   * `getByAltText` - if your element is one which supports `alt` text (`img`, `area`, and `input`), then you can use this to find that element
+   * `getByTitle` - the title attribute is not consistently read by screenreaders, and is not visible by default for sighted users
 
-1. Test IDs
+3. Test IDs
 
-   - `getByTestId` - The user cannot see (or hear) these, so this is only recommended for cases where you can't match by role or text or it doesn't make sense (e.g. the text is dynamic).
+   * `getByTestId` - The user cannot see (or hear) these, so this is only recommended for cases where you can't match by role or text or it doesn't make sense (e.g. the text is dynamic).
 
 **Avoid unnecessary "is rendering" test**
 
@@ -387,10 +387,10 @@ describe("AlertButton", () => {
 
 User actions are the bread and butter of interactive web applications. Testing user actions means ensuring that when a user clicks, drags, types, or interacts with your application in any way, the app behaves correctly.
 
-**Why is it important?**  
+**Why is it important?**\
 React components often encapsulate user interactions. Imagine a form where a user submits data or a button that toggles a specific state. If these don't work as expected, users can lose trust in our application. Or worse, our brand.
 
-**Testing Flow:**  
+**Testing Flow:**\
 To test user actions, you'll usually:
 
 1. Render the component under test.

--- a/Useful links.md
+++ b/Useful links.md
@@ -1,6 +1,7 @@
 Here are some links that might help you with your front end troubles.
 
 ## External links
+
 * [MDN](https://developer.mozilla.org/en-US/)
 * [SASS reference](http://sass-lang.com/documentation/file.SASS_REFERENCE.html)
 * [Susy documentation](http://susydocs.oddbird.net/en/latest/)
@@ -14,10 +15,12 @@ Here are some links that might help you with your front end troubles.
 * [TypeScript](https://www.typescriptlang.org/)
 * [WebpackBin](https://www.webpackbin.com/)
 * [FrontendCookies](https://infinum.com/frontend-cookies) weekly newsletter
-* [Infinum on npm](https://www.npmjs.com/~infinumco)
+* [Infinum on npmjs](https://www.npmjs.com/~infinumco)
 
 ## Useful libs
+
 ### General
+
 * [Polyglot](https://www.npmjs.com/package/polyglot-cli)
 * [Action Chainer](https://www.npmjs.com/package/action-chainer)
 * [fetch polyfill](https://github.com/github/fetch)
@@ -26,23 +29,27 @@ Here are some links that might help you with your front end troubles.
 * [loglevel](https://github.com/pimterry/loglevel)
 
 ### Dates
+
 * [Moment.js](http://momentjs.com/)
 * [date-fns](https://date-fns.org/)
 * [fecha](https://github.com/taylorhakes/fecha)
 * [Pikaday](https://github.com/dbushell/Pikaday)
 
 ### Linters
+
 * [eslint](https://www.npmjs.com/package/@infinumjs/eslint-config)
 * [eslint react](https://www.npmjs.com/package/@infinumjs/eslint-config-react)
 * [tslint](https://www.npmjs.com/package/@infinumjs/tslint-config)
 * [stylelint](https://www.npmjs.com/package/@infinumjs/stylelint-config)
 
 ### Styles
+
 * [Media mixin](https://github.com/infinum/media-blender)
 * [emotion](https://github.com/emotion-js/emotion)
 * [classnames](https://github.com/JedWatson/classnames)
 
 ### React
+
 * [CRA starter](https://www.npmjs.com/package/@infinumjs/cra-starter)
 * [react-router](https://github.com/ReactTraining/react-router)
 * [next.js](https://github.com/zeit/next.js)
@@ -52,9 +59,11 @@ Here are some links that might help you with your front end troubles.
 * [Nuka Carousel](https://github.com/FormidableLabs/nuka-carousel)
 
 ### MobX
+
 * [mobx](https://github.com/mobxjs/mobx)
 * [mobx-react](https://github.com/mobxjs/mobx-react)
 * [datx](https://www.npmjs.com/package/datx)
 
 ### Angular
+
 * [ngx-form-object](https://www.npmjs.com/package/ngx-form-object)


### PR DESCRIPTION
- Replaced all npm scripts with pnpm
- Added `-E` which sets dependency version in `package.json` to be exact latest version, instead of using `^` (to discuss if we want to do that)
- Removed deprecated template from React Native section and replaced it with expo example, IMO it's better because you need to know what you're doing when using a template since they're not really universal
- Replaced TODO url in React Native chaper to actual chapter URL
- Removed TODO theming URL in React Native Styling chapter as we don't (and probably shouldn't) have such chapter for React
- Formatted updated chapters with remark
- Updated Changesets Github Actions example


Related PR in private repository:
https://github.com/infinum/frontend-handbook-private/pull/80