### PR TITLE
Update react hooks testing and msw references

### DIFF
--- a/React/Testing/Best practices.md
+++ b/React/Testing/Best practices.md
@@ -42,14 +42,6 @@ Use [testing-library/user-event](https://github.com/testing-library/user-event) 
 pnpm install -D -E @testing-library/user-event
 ```
 
-### Testing hooks
-
-Use [react-hooks-testing-library](https://github.com/testing-library/react-hooks-testing-library) for testing hooks:
-
-```bash
-pnpm install -D -E @testing-library/react-hooks
-```
-
 ## Utils
 
 ### Mock providers and store
@@ -730,7 +722,8 @@ test("TodoComponent renders correct number of rows", async () => {
 
 ## Hooks
 
-`react-hooks-testing-library` creates a simple test harness for React hooks that handles running them within the body of a function component, as well as providing various useful utility functions for updating the inputs and retrieving the outputs of your custom hook. This library aims to provide a testing experience as close as possible to how your hook is used in a real component.
+`@testing-library/react` provides `renderHook` and `act` for testing custom hooks. These utilities create a simple test harness that handles running hooks within the body of a function component, as well as providing various useful utility functions for updating the inputs and retrieving the outputs of your custom hook. This approach provides a testing experience as close as possible to how your hook is used in a real component.
+
 
 ### Example hook:
 

--- a/React/Testing/Best practices.md
+++ b/React/Testing/Best practices.md
@@ -688,7 +688,7 @@ For more info about testing asynchronous code read [docs](https://jestjs.io/docs
 Example:
 
 ```tsx
-import { rest } from "msw";
+import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 
 const apiEndpoint = "http://localhost:3000";
@@ -697,8 +697,8 @@ const mockTodoData = [{ title: "Todo #1", todos: [] }];
 
 const server = setupServer(
   // Describe the requests to mock.
-  rest.post(`${apiEndpoint}/api/todo-lists`, (req, res, ctx) => {
-    return res(ctx.json(mockTodoData));
+  http.post(`${apiEndpoint}/api/todo-lists`, () => {
+    return HttpResponse.json(mockTodoData);
   })
 );
 
@@ -723,7 +723,6 @@ test("TodoComponent renders correct number of rows", async () => {
 ## Hooks
 
 `@testing-library/react` provides `renderHook` and `act` for testing custom hooks. These utilities create a simple test harness that handles running hooks within the body of a function component, as well as providing various useful utility functions for updating the inputs and retrieving the outputs of your custom hook. This approach provides a testing experience as close as possible to how your hook is used in a real component.
-
 
 ### Example hook:
 

--- a/React/Testing/Timers.md
+++ b/React/Testing/Timers.md
@@ -56,10 +56,12 @@ _Properly mocking and controlling timeouts can lead to more consistent, faster, 
 A simple example is waiting for our component to fetch an external resource from an API endpoint (_We are using **MSW** to mock the endpoint_). `waitForElementToBeRemoved` function from React Testing Library, which `awaits` for the `queryByText` to return `true`.
 
 ```jsx
+import { http, HttpResponse } from "msw";
+
 it("should show empty state", async () => {
   server.use(
-    rest.get("/api/lists", (req, res, ctx) => {
-      return res(ctx.json([]));
+    http.get("/api/lists", () => {
+      return HttpResponse.json([]);
     })
   );
 

--- a/React/Testing/User actions.md
+++ b/React/Testing/User actions.md
@@ -182,12 +182,12 @@ Many times, we have complex forms that are very important to our business runnin
 First, we set up **MSW** (Mock Service Worker) to handle API requests made by the form. This will ensure we have more control over the responses, so we can test for different scenarios.
 
 ```jsx
-import { rest } from "msw";
+import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 
 const server = setupServer(
-  rest.post(testApiUrl("/api/login"), (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(true));
+  http.post(testApiUrl("/api/login"), () => {
+    return HttpResponse.json(true, { status: 200 });
   })
 );
 


### PR DESCRIPTION
Updates `react-hooks-testing-library` references to point to `@testing-library/react`, and updates msw code blocks to reflect the newer standards-based `HttpRequest` and `HttpResponse` types.